### PR TITLE
Allows pagination for MongoDB

### DIFF
--- a/src/adapters/datasources/datasource-mongodb.js
+++ b/src/adapters/datasources/datasource-mongodb.js
@@ -250,12 +250,13 @@ export class DataSourceMongoDb extends DataSourceMemory {
    *
    * @returns
    */
-  async mongoFind ({ filter, sort, limit, aggregate, skip, offset } = {}) {
-    console.log({ filter })
+  async mongoFind ({ filter, sort, limit, aggregate, skip } = {}) {
+    console.log('Aegis MongoDataAdapter: filter',{ filter })
     let cursor = (await this.collection()).find(filter)
     if (sort) cursor = cursor.sort(sort)
     if (limit) cursor = cursor.limit(limit)
     if (aggregate) cursor = cursor.aggregate(aggregate)
+    if (skip) cursor = cursor.skip(skip)
     return cursor
   }
 

--- a/src/adapters/datasources/datasource-mongodb.js
+++ b/src/adapters/datasources/datasource-mongodb.js
@@ -259,9 +259,9 @@ export class DataSourceMongoDb extends DataSourceMemory {
     console.log('Aegis MongoDataAdapter: filter',{ filter })
     let cursor = (await this.collection()).find(filter)
     if (sort) cursor = cursor.sort(sort)
-    if (limit) cursor = cursor.limit(limit)
     if (aggregate) cursor = cursor.aggregate(aggregate)
     if (skip) cursor = cursor.skip(skip)
+    if (limit) cursor = cursor.limit(limit)
     return cursor
   }
 


### PR DESCRIPTION
tested for skip, limit, sort and query

we are able to paginate though the list fully. Order of the execution matters for results hence fixed for wide range of cases.

TestQuery: __query={},_sort={createTime:1}&__limit=2&__skip=2

<a href="https://gitpod.io/#https://github.com/module-federation/aegis/pull/214"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

