### PR TITLE
Fix Custom Paths

### DIFF
--- a/src/adapters/controllers/http-adapter.js
+++ b/src/adapters/controllers/http-adapter.js
@@ -29,6 +29,7 @@ export default function buildCallback(controller) {
       path: req.path,
       res: res,
       headers: req.headers,
+      routeOverride: req.routeOverride,
       log(func) {
         console.info({
           function: func,

--- a/src/adapters/controllers/http-adapter.js
+++ b/src/adapters/controllers/http-adapter.js
@@ -29,7 +29,6 @@ export default function buildCallback(controller) {
       path: req.path,
       res: res,
       headers: req.headers,
-      routeOverride: req.routeOverride,
       log(func) {
         console.info({
           function: func,

--- a/src/adapters/controllers/post-invoke-port.js
+++ b/src/adapters/controllers/post-invoke-port.js
@@ -11,7 +11,7 @@ export default function anyInvokePortFactory (invokePort) {
     try {
       httpRequest.log(anyInvokePort.name)
       const result = await invokePort({
-        port: httpRequest.params.port || httpRequest.routeOverride,
+        port: httpRequest.params.port,
         args: httpRequest.body,
         id: httpRequest.params.id || null
       })

--- a/src/adapters/controllers/post-invoke-port.js
+++ b/src/adapters/controllers/post-invoke-port.js
@@ -10,9 +10,8 @@ export default function anyInvokePortFactory (invokePort) {
   return async function anyInvokePort (httpRequest) {
     try {
       httpRequest.log(anyInvokePort.name)
-
       const result = await invokePort({
-        port: httpRequest.params.port,
+        port: httpRequest.params.port || httpRequest.routeOverride,
         args: httpRequest.body,
         id: httpRequest.params.id || null
       })

--- a/src/aegis.js
+++ b/src/aegis.js
@@ -180,7 +180,7 @@ async function handle(path, method, req, res) {
     return
   }
 
-  const requestInfo = Object.assign(req, { params: routeInfo.params, routeOverride: routeOverrides.get(path) })
+  const requestInfo = Object.assign(req, { params: routeInfo.params })
 
   try {
     // track this request
@@ -189,7 +189,8 @@ async function handle(path, method, req, res) {
         ['id', req.headers['idempotency-key'] || nanoid()],
         ['begin', Date.now()],
         ['user', req.user],
-        ['res', res]
+        ['res', res],
+        ['path', path]
       ])
     )
     console.debug(`enter context ${requestContext.getStore().get('id')}`)

--- a/src/aegis.js
+++ b/src/aegis.js
@@ -75,6 +75,7 @@ class RouteMap extends Map {
 }
 
 const routes = new RouteMap()
+const routeOverrides = new Map()
 
 function buildPath(ctrl, path) {
   return ctrl.path && ctrl.path[path.name]
@@ -93,17 +94,26 @@ const router = {
       .filter(ctrl => !ctrl.internal)
       .forEach(ctrl => {
         if (ports) {
-          if (ctrl.ports)
-            Object.values(ctrl.ports).forEach(port => {
-              if (checkAllowedMethods(ctrl, method))
+          if (ctrl.ports) {
+            for(const portName in ctrl.ports) {
+              const port = ctrl.ports[portName];
+              if(port.path) {
+                routeOverrides.set(port.path, portName);
+              }
+
+              if (checkAllowedMethods(ctrl, method)) { 
                 routes.set(port.path || path(ctrl.endpoint), {
                   [method]: adapter(ctrl.fn)
                 })
-            })
-        } else
+              }
+            }
+          }
+       
+        } else {
           routes.set(buildPath(ctrl, path), {
             [method]: adapter(ctrl.fn)
           })
+        }
       })
   },
 
@@ -170,7 +180,7 @@ async function handle(path, method, req, res) {
     return
   }
 
-  const requestInfo = Object.assign(req, { params: routeInfo.params })
+  const requestInfo = Object.assign(req, { params: routeInfo.params, routeOverride: routeOverrides.get(path) })
 
   try {
     // track this request

--- a/src/domain/use-cases/index.js
+++ b/src/domain/use-cases/index.js
@@ -22,7 +22,7 @@ import makeServiceMesh from "./create-service-mesh.js"
 import { PortEventRouter } from "../event-router"
 import { isMainThread } from "worker_threads"
 import { hostConfig } from "../../config"
-import { requestContext } from "../util/async-context"
+import * as context from "../util/async-context"
 
 export const serviceMeshPlugin =
   hostConfig.services.activeServiceMesh ||
@@ -115,12 +115,13 @@ function buildOptions (spec, options) {
     modelName: spec.modelName,
     models: ModelFactory,
     broker: EventBrokerFactory.getInstance(),
-    handlers: spec.eventHandlers
+    handlers: spec.eventHandlers,
+    context,
   }
 
   if (isMainThread) {
     const ds = getDataSource(spec.modelName, options)
-    return {
+    return { 
       ...invariant,
       // main thread does not write to persistent store
       repository: ds,

--- a/src/domain/use-cases/invoke-port.js
+++ b/src/domain/use-cases/invoke-port.js
@@ -55,6 +55,8 @@ export default function makeInvokePort ({
 
           const portTuple = Object.entries(specPorts).filter((port) => port[1].path === path);
           console.log("PORT_TUPLE::::", portTuple)
+          console.log("PORT_NAME:::", portTuple[0]);
+          console.log("SERVICE:::", service);
 
           if(!portTuple) {
             throw new Error('no port specified');

--- a/src/domain/use-cases/invoke-port.js
+++ b/src/domain/use-cases/invoke-port.js
@@ -53,14 +53,13 @@ export default function makeInvokePort ({
           console.log("SPEC_PORTS::::", specPorts)
           console.log("SPEC_PORT_ENTRIES:::", Object.entries(specPorts));
 
-          const [ portName ] = Object.entries(specPorts).filter((port) => port[1].path === path);
-          console.log("PORT_TUPLE::::", portName)
+          const portTuple = Object.entries(specPorts).filter((port) => port[1].path === path);
+          console.log("PORT_TUPLE::::", portTuple)
 
-
-          if(!portName) {
+          if(!portTuple) {
             throw new Error('no port specified');
           }
-          if(!service[portName]) {
+          if(!service[portTuple[0]]) {
             throw new Error('no port found');
           }
 

--- a/src/domain/use-cases/invoke-port.js
+++ b/src/domain/use-cases/invoke-port.js
@@ -23,6 +23,7 @@ export default function makeInvokePort ({
   threadpool,
   modelName,
   models,
+  context,
   authorize = async x => await x()
 } = {}) {
   async function findModelService (id = null) {
@@ -46,10 +47,14 @@ export default function makeInvokePort ({
         } 
 
         if(!port) {
-          const path = input.context.get('path');
-          const portTupleWithCustomPath = Object.entries(object1).filter((port) => port[1].path === path);
+          const specPorts = service.getPorts();
+          const path = context['requestContext'].getStore().get('path');
+          const portTupleWithCustomPath = Object.entries(specPorts).filter((port) => port[1].path === path);
           if(!portTupleWithCustomPath) {
             throw new Error('no port specified');
+          }
+          if(!service[portTupleWithCustomPath[0]]) {
+            throw new Error('no port found');
           }
           return await service[portTupleWithCustomPath[0]](input.jobData);
         }

--- a/src/domain/use-cases/invoke-port.js
+++ b/src/domain/use-cases/invoke-port.js
@@ -49,19 +49,11 @@ export default function makeInvokePort ({
         if(!port) {
           const specPorts = service.getPorts();
           const path = context['requestContext'].getStore().get('path');
-          console.log("PATH::::", path);
-          console.log("SPEC_PORTS::::", specPorts)
-          console.log("SPEC_PORT_ENTRIES:::", Object.entries(specPorts));
-
-          const portTuple = Object.entries(specPorts).filter((port) => port[1].path === path);
-          console.log("PORT_TUPLE::::", portTuple)
-          console.log("PORT_NAME:::", portTuple[0]);
-          console.log("SERVICE:::", service);
-
-          if(!portTuple) {
+          const [ [ portName ] ] = Object.entries(specPorts).filter((port) => port[1].path === path);
+          if(!portName) {
             throw new Error('no port specified');
           }
-          if(!service[portTuple[0]]) {
+          if(!service[portName]) {
             throw new Error('no port found');
           }
 

--- a/src/domain/use-cases/invoke-port.js
+++ b/src/domain/use-cases/invoke-port.js
@@ -39,9 +39,21 @@ export default function makeInvokePort ({
       return threadpool.runJob(invokePort.name, input, modelName)
     } else {
       try {
-        const { jobData: {id = null, port} } = input 
+        const { jobData: {id = null, port = null} } = input;
         const service = await findModelService(id)
-        if (!service) throw new Error('could not find service')
+        if (!service) {
+          throw new Error('could not find service')
+        } 
+
+        if(!port) {
+          const path = input.context.get('path');
+          const portTupleWithCustomPath = Object.entries(object1).filter((port) => port[1].path === path);
+          if(!portTupleWithCustomPath) {
+            throw new Error('no port specified');
+          }
+          return await service[portTupleWithCustomPath[0]](input.jobData);
+        }
+
         return await service[port](input.jobData)
       } catch (error) {
         return AppError(error)

--- a/src/domain/use-cases/invoke-port.js
+++ b/src/domain/use-cases/invoke-port.js
@@ -39,10 +39,10 @@ export default function makeInvokePort ({
       return threadpool.runJob(invokePort.name, input, modelName)
     } else {
       try {
-        const { id = null, port } = input
+        const { jobData: {id = null, port} } = input 
         const service = await findModelService(id)
         if (!service) throw new Error('could not find service')
-        return await service[port](input)
+        return await service[port](input.jobData)
       } catch (error) {
         return AppError(error)
       }

--- a/src/domain/use-cases/invoke-port.js
+++ b/src/domain/use-cases/invoke-port.js
@@ -53,17 +53,18 @@ export default function makeInvokePort ({
           console.log("SPEC_PORTS::::", specPorts)
           console.log("SPEC_PORT_ENTRIES:::", Object.entries(specPorts));
 
-          const portTupleWithCustomPath = Object.entries(specPorts).filter((port) => port[1].path === path);
+          const [ portName ] = Object.entries(specPorts).filter((port) => port[1].path === path);
           console.log("PORT_TUPLE::::", portTupleWithCustomPath)
 
 
-          if(!portTupleWithCustomPath) {
+          if(!portName) {
             throw new Error('no port specified');
           }
-          if(!service[portTupleWithCustomPath[0]]) {
+          if(!service[portName]) {
             throw new Error('no port found');
           }
-          return await service[portTupleWithCustomPath[0]](input);
+
+          return await service[portName](input);
         }
 
         return await service[port](input)

--- a/src/domain/use-cases/invoke-port.js
+++ b/src/domain/use-cases/invoke-port.js
@@ -49,7 +49,14 @@ export default function makeInvokePort ({
         if(!port) {
           const specPorts = service.getPorts();
           const path = context['requestContext'].getStore().get('path');
+          console.log("PATH::::", path);
+          console.log("SPEC_PORTS::::", specPorts)
+          console.log("SPEC_PORT_ENTRIES:::", Object.entries(specPorts));
+
           const portTupleWithCustomPath = Object.entries(specPorts).filter((port) => port[1].path === path);
+
+
+
           if(!portTupleWithCustomPath) {
             throw new Error('no port specified');
           }

--- a/src/domain/use-cases/invoke-port.js
+++ b/src/domain/use-cases/invoke-port.js
@@ -54,7 +54,7 @@ export default function makeInvokePort ({
           console.log("SPEC_PORT_ENTRIES:::", Object.entries(specPorts));
 
           const [ portName ] = Object.entries(specPorts).filter((port) => port[1].path === path);
-          console.log("PORT_TUPLE::::", portTupleWithCustomPath)
+          console.log("PORT_TUPLE::::", portName)
 
 
           if(!portName) {

--- a/src/domain/use-cases/invoke-port.js
+++ b/src/domain/use-cases/invoke-port.js
@@ -54,7 +54,7 @@ export default function makeInvokePort ({
           console.log("SPEC_PORT_ENTRIES:::", Object.entries(specPorts));
 
           const portTupleWithCustomPath = Object.entries(specPorts).filter((port) => port[1].path === path);
-
+          console.log("PORT_TUPLE::::", portTupleWithCustomPath)
 
 
           if(!portTupleWithCustomPath) {

--- a/src/domain/use-cases/invoke-port.js
+++ b/src/domain/use-cases/invoke-port.js
@@ -40,7 +40,7 @@ export default function makeInvokePort ({
       return threadpool.runJob(invokePort.name, input, modelName)
     } else {
       try {
-        const { jobData: {id = null, port = null} } = input;
+        const { id = null, port = null} = input;
         const service = await findModelService(id)
         if (!service) {
           throw new Error('could not find service')
@@ -56,10 +56,10 @@ export default function makeInvokePort ({
           if(!service[portTupleWithCustomPath[0]]) {
             throw new Error('no port found');
           }
-          return await service[portTupleWithCustomPath[0]](input.jobData);
+          return await service[portTupleWithCustomPath[0]](input);
         }
 
-        return await service[port](input.jobData)
+        return await service[port](input)
       } catch (error) {
         return AppError(error)
       }


### PR DESCRIPTION
**Problem**

When using the `path` key in the model, Aegis would throw `service[port] is undefined`. The root cause of this was because the `invokePort` function expected the port name inside of the route params.

**Fix**

I created a map right below the `RouteMap` that holds all of the custom route mapped to their proper port when Aegis builds the route. From there the http controller will pass the custom port name in the request and then on to invoke port. 

**Potential Problems**

I cannot figure out why `jobData` was needed. `input` in `invokePort` didn't change, however, adding one field changed the entire structure of the input. Regardless, both calling by port and the custom route were tested.


**Testing**

Tested on `createUser` port in Britelite aegis-app by overriding the autocreated POST (create) route. e.g. `path: /api/aegis/models/users`



<a href="https://gitpod.io/#https://github.com/module-federation/aegis/pull/236"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

